### PR TITLE
Adding in the right url for Mani Osterias gift card page

### DIFF
--- a/_data/businesses.csv
+++ b/_data/businesses.csv
@@ -37,7 +37,7 @@ Food & Drink,Ann Arbor,Jolly Pumpkin,https://nubco.worldsecuresystems.com/jp/Gif
 Food & Drink,Ann Arbor,Knight's Steakhouse,https://knightsrestaurants.com/gift-cards
 Food & Drink,Ann Arbor,La Dolce Vita,http://thechophouseannarbor.com/giftcards/
 Food & Drink,Ann Arbor,Logan Restaurant,http://logan-restaurant.com/gift-certificates
-Food & Drink,Ann Arbor,Mani Osteria & Bar,http://maniosteria.com/purchase-gift-cards
+Food & Drink,Ann Arbor,Mani Osteria & Bar,https://manigroup.fanzootechnology.com/gift-cards/
 Food & Drink,Ann Arbor,Mikette Bistro,http://www.mikettea2.com/gift-cards
 Food & Drink,Ann Arbor,Miss Kim,https://squareup.com/gift/3HJRS5Y1XNDHM/order
 Food & Drink,Ann Arbor,Monahan's Seafood Market,https://monahansseafood.com/shop/store/


### PR DESCRIPTION
Fixes issue#2, where the gift card link for Mani's osteria leads to a 404 page.